### PR TITLE
Update lita-slack to 1.8.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem "lita"
 gem "twitter"
 
 group :production do
-  gem "lita-slack", github: 'litaio/lita-slack', branch: 'master'
+  gem "lita-slack"
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,15 +1,3 @@
-GIT
-  remote: git://github.com/litaio/lita-slack.git
-  revision: 38a968fd88e46fb5448420296b6415ecfe946a46
-  branch: master
-  specs:
-    lita-slack (1.7.2)
-      eventmachine
-      faraday
-      faye-websocket (>= 0.8.0)
-      lita (>= 4.7.0)
-      multi_json
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -25,12 +13,12 @@ GEM
     domain_name (0.5.25)
       unf (>= 0.0.5, < 1.0.0)
     equalizer (0.0.10)
-    eventmachine (1.2.0.1)
+    eventmachine (1.2.3)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
     faraday_middleware (0.10.0)
       faraday (>= 0.7.4, < 0.10)
-    faye-websocket (0.10.3)
+    faye-websocket (0.10.7)
       eventmachine (>= 0.12.0)
       websocket-driver (>= 0.5.1)
     hashie (3.4.3)
@@ -46,10 +34,10 @@ GEM
     http_router (0.11.2)
       rack (>= 1.0.0)
       url_mount (~> 0.2.1)
-    i18n (0.7.0)
+    i18n (0.8.1)
     ice_nine (0.11.2)
     json (1.8.3)
-    lita (4.7.0)
+    lita (4.7.1)
       bundler (>= 1.3)
       faraday (>= 0.8.7)
       http_router (>= 0.11.2)
@@ -57,21 +45,27 @@ GEM
       ice_nine (>= 0.11.0)
       multi_json (>= 1.7.7)
       puma (>= 2.7.1)
-      rack (>= 1.5.2)
+      rack (>= 1.5.2, < 2.0.0)
       rb-readline (>= 0.5.1)
       redis-namespace (>= 1.3.0)
       thor (>= 0.18.1)
+    lita-slack (1.8.0)
+      eventmachine
+      faraday
+      faye-websocket (>= 0.8.0)
+      lita (>= 4.7.1)
+      multi_json
     memoizable (0.4.2)
       thread_safe (~> 0.3, >= 0.3.1)
     minitest (5.8.3)
-    multi_json (1.11.2)
+    multi_json (1.12.1)
     multipart-post (2.0.0)
     naught (1.1.0)
-    puma (3.2.0)
-    rack (1.6.4)
-    rb-readline (0.5.3)
-    redis (3.2.2)
-    redis-namespace (1.5.2)
+    puma (3.8.2)
+    rack (1.6.5)
+    rb-readline (0.5.4)
+    redis (3.3.3)
+    redis-namespace (1.5.3)
       redis (~> 3.0, >= 3.0.4)
     rspec (3.4.0)
       rspec-core (~> 3.4.0)
@@ -87,7 +81,7 @@ GEM
       rspec-support (~> 3.4.0)
     rspec-support (3.4.1)
     simple_oauth (0.3.1)
-    thor (0.19.1)
+    thor (0.19.4)
     thread_safe (0.3.5)
     twitter (5.15.0)
       addressable (~> 2.3)
@@ -107,7 +101,7 @@ GEM
     unf_ext (0.0.7.1)
     url_mount (0.2.1)
       rack
-    websocket-driver (0.6.3)
+    websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
 
@@ -119,7 +113,7 @@ DEPENDENCIES
   faraday_middleware
   hashie
   lita
-  lita-slack!
+  lita-slack
   rspec
   twitter
 


### PR DESCRIPTION
https://github.com/litaio/lita-slack/commit/38a968fd88e46fb5448420296b6415ecfe946a46 was released with 1.8.0.
Changelog: https://github.com/litaio/lita-slack/releases/tag/v1.8.0

Related to a Hackerone report which points out the use of insecure git protocol in [Gemfile.lock](https://github.com/rubygems/rubygems-lita/compare/master...sonalkr132:update-lita-slack?expand=1#diff-e79a60dc6b85309ae70a6ea8261eaf95L2).